### PR TITLE
Fix empty expires string in cookies leading to load exception

### DIFF
--- a/songs_to_youtube/upload.py
+++ b/songs_to_youtube/upload.py
@@ -47,7 +47,7 @@ class JSONFileCookieJar(FileCookieJar):
                 cookie["path"],
                 True,
                 cookie["secure"],
-                cookie["expires"],
+                cookie["expires"] or None,
                 False,
                 None,
                 None,


### PR DESCRIPTION
cookiejar cannot handle "" (empty string) as expiry