### PR TITLE
Capture Website Metadata

### DIFF
--- a/songs_to_youtube/metadata.py
+++ b/songs_to_youtube/metadata.py
@@ -41,6 +41,8 @@ class Metadata:
                 if isinstance(f.tags, mutagen.easyid3.EasyID3):
                     f = mutagen.File(path)
                 for key in f:
+                    if key.startswith("WOAF"):
+                        self.tags["website"] = make_value_qt_safe(f[key])
                     if key.startswith("COM"):
                         # load comment data here since comment frame keys have
                         # language suffix we can't just register text key COMM

--- a/songs_to_youtube/metadata.py
+++ b/songs_to_youtube/metadata.py
@@ -41,7 +41,7 @@ class Metadata:
                 if isinstance(f.tags, mutagen.easyid3.EasyID3):
                     f = mutagen.File(path)
                 for key in f:
-                    if key.startswith("WOAF"):
+                    if key.startswith("WOAF") or key.startswith("WAF"):
                         self.tags["website"] = make_value_qt_safe(f[key])
                     if key.startswith("COM"):
                         # load comment data here since comment frame keys have


### PR DESCRIPTION
Gets website metadata from the standard ID3 "WOAF" mapping for mp3 and adds it to the song's metadata.

Non-mp3 tracks usually get the "wwwaudiofile" key populated correctly in songs-to-youtube if it is available, but mp3 files' "WOAF" metadata wasn't getting pulled in at all previously.

I titled the key "website" because that is what this project had previously used (and it is the key currently used in the default song description settings).