### PR TITLE
Add Ctrl+S save keybinding

### DIFF
--- a/songs_to_youtube/song_settings_widget.py
+++ b/songs_to_youtube/song_settings_widget.py
@@ -47,6 +47,12 @@ class SongSettingsWidget(QWidget):
         # resize UI when widget is resized
         self.findChild(QWidget, "songSettingsWindow").resize(event.size())
 
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_S and event.modifiers() == Qt.ControlModifier:
+            self.save_settings()
+        else:
+            super().keyPressEvent(event)
+    
     def connect_actions(self):
         cover_art_button = self.findChild(QPushButton, "coverArtButton")
         cover_art_button.clicked.connect(self.change_cover_art)


### PR DESCRIPTION
Allows users to save a click to the "OK" button by pressing Ctrl+S to save edits in the Song Settings Widget instead.

I can see other keybindings being useful but this is the most uncontroversial and useful I think.

Edit: sorry, i probably should have opened a feature request issue before the PR for feedback.